### PR TITLE
added two unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install uv
+        uv sync
 
     - name: Check code quality with ruff
       continue-on-error: true

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "python.testing.pytestArgs": [
+        "tests"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}

--- a/src/demo.py
+++ b/src/demo.py
@@ -1,9 +1,0 @@
-from data_ingestion import data_ingestion
-from db_sync import db_sync
-
-def run_demo():
-    # data_ingestion()
-    db_sync()   
-
-if __name__ == "__main__":
-    run_demo()

--- a/src/logger.py
+++ b/src/logger.py
@@ -1,3 +1,4 @@
+import os
 import logging
 import logging.handlers
 import json
@@ -25,8 +26,12 @@ def setup_logging():
     formatter = logging.Formatter()
     formatter.format = format_json
 
+    log_dir = "./logs"
+    os.makedirs(log_dir, exist_ok=True)   # ensure folder exists
+    log_file = os.path.join(log_dir, "application.log")
+
     file_handler = logging.handlers.RotatingFileHandler(
-        "./logs/application.log", maxBytes=2 * 1024 * 1024, backupCount=1
+        log_file, maxBytes=2 * 1024 * 1024, backupCount=1
     )
     file_handler.setFormatter(formatter)
 
@@ -35,6 +40,7 @@ def setup_logging():
 
     logger = logging.getLogger("json_logger")
     logger.setLevel(logging.INFO)
+
     if not logger.handlers:
         logger.addHandler(file_handler)
         logger.addHandler(console_handler)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,2 +1,32 @@
-def test_placeholder():
-    assert True
+import sys
+import pathlib
+import io
+import polars as pl
+from data_ingestion import convert_dataframe_to_parquet
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+
+def test_convert_dataframe_to_parquet_roundtrip():
+    original_df = pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+
+    parquet_buffer = convert_dataframe_to_parquet(original_df)
+
+    assert parquet_buffer is not None, "Expected a BytesIO buffer, got None"
+    assert isinstance(parquet_buffer, io.BytesIO), "Result should be an in-memory BytesIO buffer"
+
+    parquet_buffer.seek(0)
+    roundtrip_df = pl.read_parquet(parquet_buffer)
+
+    # Compare via to_dicts() for compatibility with installed Polars version
+    assert roundtrip_df.to_dicts() == original_df.to_dicts(), "Round-tripped DataFrame should equal the original"
+
+
+def test_convert_dataframe_to_parquet_handles_exceptions():
+    """If the object's write_parquet raises, the function should return None."""
+
+    class BadWriter:
+        def write_parquet(self, buffer):
+            raise ValueError("boom")
+
+    bad_writer = BadWriter()
+    conversion_result = convert_dataframe_to_parquet(bad_writer)
+    assert conversion_result is None


### PR DESCRIPTION
# Description

This pull request introduces a new test suite for validating the `convert_dataframe_to_parquet` function and configures the project to use `pytest` for testing. It also removes the demo script from the codebase. The most important changes are grouped below:

**Testing improvements:**

* Added comprehensive tests for the `convert_dataframe_to_parquet` function in `tests/test_main.py`, including round-trip conversion and exception handling.
* Configured VSCode to use `pytest` as the default test runner and disabled `unittest` in `.vscode/settings.json`.

**Codebase cleanup:**

* Removed the unused demo script `src/demo.py` from the repository.


## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Chore
